### PR TITLE
Implement CORE-002

### DIFF
--- a/R/compute_zindex.R
+++ b/R/compute_zindex.R
@@ -1,0 +1,38 @@
+#' Compute 3D Z-order (Morton) index
+#'
+#' Interleaves bits of the x, y and z coordinates to create a
+#' 32-bit unsigned integer Morton code. Coordinates must be
+#' non-negative integers and less than 2^`max_coord_bits`.
+#'
+#' @param x,y,z Integer vectors of equal length with 0-based
+#'   voxel coordinates.
+#' @param max_coord_bits Maximum number of bits used to represent
+#'   each coordinate (default 10).
+#'
+#' @return Integer vector of the same length as `x` with the
+#'   computed Morton codes.
+#' @export
+compute_zindex <- function(x, y, z, max_coord_bits = 10) {
+  if (length(x) != length(y) || length(y) != length(z)) {
+    stop("x, y and z must have the same length")
+  }
+  if (any(x < 0 | y < 0 | z < 0)) {
+    stop("coordinates must be non-negative")
+  }
+  limit <- bitwShiftL(1L, max_coord_bits)
+  if (any(x >= limit | y >= limit | z >= limit)) {
+    stop("coordinates exceed range defined by max_coord_bits")
+  }
+
+  x <- as.integer(x)
+  y <- as.integer(y)
+  z <- as.integer(z)
+  res <- integer(length(x))
+  for (i in 0:(max_coord_bits - 1L)) {
+    mask <- bitwShiftL(1L, i)
+    res <- bitwOr(res, bitwShiftL(bitwAnd(x, mask), 3L * i))
+    res <- bitwOr(res, bitwShiftL(bitwAnd(y, mask), 3L * i + 1L))
+    res <- bitwOr(res, bitwShiftL(bitwAnd(z, mask), 3L * i + 2L))
+  }
+  res
+}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(fmriarrow)
+
+test_check("fmriarrow")

--- a/tests/testthat/test-compute_zindex.R
+++ b/tests/testthat/test-compute_zindex.R
@@ -1,0 +1,23 @@
+library(testthat)
+
+context("compute_zindex")
+
+test_that("basic zindex values", {
+  expect_equal(compute_zindex(0, 0, 0), 0L)
+  expect_equal(compute_zindex(1, 0, 0), 1L)
+  expect_equal(compute_zindex(0, 1, 0), 2L)
+  expect_equal(compute_zindex(0, 0, 1), 4L)
+  expect_equal(compute_zindex(1, 1, 1), 7L)
+})
+
+test_that("vectorized input works", {
+  x <- c(0, 1, 0, 1)
+  y <- c(0, 0, 1, 1)
+  z <- c(0, 0, 0, 0)
+  expect_equal(compute_zindex(x, y, z), c(0L, 1L, 2L, 3L))
+})
+
+test_that("input validation", {
+  expect_error(compute_zindex(-1, 0, 0))
+  expect_error(compute_zindex(0, 0, 1024, max_coord_bits = 10))
+})


### PR DESCRIPTION
## Summary
- add `compute_zindex()` for Morton ordering
- include unit tests for `compute_zindex`

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa74dff00832db33f644f3a45ebb8