### PR TITLE
Implement CORE-003 stub

### DIFF
--- a/R/neurovec_to_fpar.R
+++ b/R/neurovec_to_fpar.R
@@ -1,0 +1,38 @@
+#' Convert a NeuroVec object to a Parquet file
+#'
+#' This is the initial stub for the conversion function described in the
+#' project proposal. It currently only performs basic input validation and
+#' extracts the associated NeuroSpace object. Later tasks will implement the
+#' actual voxel iteration and Parquet writing steps.
+#'
+#' @param neuro_vec_obj A `neuroim2::NeuroVec` object.
+#' @param output_parquet_path Path to the Parquet file to create.
+#' @param subject_id Identifier for the subject being converted.
+#' @param session_id Optional session identifier.
+#' @param task_id Optional task identifier.
+#' @param run_id Optional run identifier.
+#' @param ... Additional arguments reserved for future extensions.
+#'
+#' @return A list containing the extracted `NeuroSpace` object and the
+#'   supplied identifiers. The return value is primarily for testing
+#'   purposes and should not be considered part of the final API.
+#' @export
+neurovec_to_fpar <- function(neuro_vec_obj, output_parquet_path,
+                             subject_id, session_id = NULL,
+                             task_id = NULL, run_id = NULL, ...) {
+  if (!inherits(neuro_vec_obj, "NeuroVec")) {
+    stop("neuro_vec_obj must inherit from 'NeuroVec'")
+  }
+
+  space_obj <- neuroim2::space(neuro_vec_obj)
+
+  list(
+    neuro_vec_obj = neuro_vec_obj,
+    output_parquet_path = output_parquet_path,
+    subject_id = subject_id,
+    session_id = session_id,
+    task_id = task_id,
+    run_id = run_id,
+    space = space_obj
+  )
+}

--- a/tests/testthat/test-neurovec_to_fpar.R
+++ b/tests/testthat/test-neurovec_to_fpar.R
@@ -1,0 +1,16 @@
+library(testthat)
+
+context("neurovec_to_fpar")
+
+test_that("input must be a NeuroVec", {
+  expect_error(neurovec_to_fpar(list(), "file.parquet", "sub01"))
+})
+
+# This test exercises the basic return structure when neuroim2 is available.
+test_that("basic invocation", {
+  skip_if_not_installed("neuroim2")
+
+  nv <- neuroim2::emptyNeuroVec(c(1,1,1,1))
+  res <- neurovec_to_fpar(nv, tempfile(), "sub01")
+  expect_true(inherits(res$space, "NeuroSpace"))
+})


### PR DESCRIPTION
## Summary
- implement skeleton of `neurovec_to_fpar` for CORE-003
- add basic tests for input checking

## Testing
- `R -q -e "library(testthat); test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa8411f50832db70cc5b466bd7bc1