### PR TITLE
Implement CORE-005 sorting

### DIFF
--- a/R/neurovec_to_fpar.R
+++ b/R/neurovec_to_fpar.R
@@ -13,9 +13,10 @@
 #' @param run_id Optional run identifier.
 #' @param ... Additional arguments reserved for future extensions.
 #'
-#' @return A list containing the extracted `NeuroSpace` object and the
-#'   supplied identifiers. The return value is primarily for testing
-#'   purposes and should not be considered part of the final API.
+#' @return A list containing the extracted `NeuroSpace`, the voxel data,
+#'   and the generated Arrow table. The return value is primarily for
+#'   testing purposes and should not be considered part of the final
+#'   API.
 #' @export
 neurovec_to_fpar <- function(neuro_vec_obj, output_parquet_path,
                              subject_id, session_id = NULL,
@@ -59,6 +60,9 @@ neurovec_to_fpar <- function(neuro_vec_obj, output_parquet_path,
   )
   voxel_data$bold <- I(bold)
 
+  arrow_tbl <- arrow::arrow_table(voxel_data)
+  arrow_tbl <- dplyr::arrange(arrow_tbl, zindex)
+
   list(
     neuro_vec_obj = neuro_vec_obj,
     output_parquet_path = output_parquet_path,
@@ -67,6 +71,7 @@ neurovec_to_fpar <- function(neuro_vec_obj, output_parquet_path,
     task_id = task_id,
     run_id = run_id,
     space = space_obj,
-    voxel_data = voxel_data
+    voxel_data = voxel_data,
+    arrow_table = arrow_tbl
   )
 }

--- a/tests/testthat/test-neurovec_to_fpar.R
+++ b/tests/testthat/test-neurovec_to_fpar.R
@@ -17,6 +17,7 @@ test_that("basic invocation", {
 
 test_that("voxel extraction works", {
   skip_if_not_installed("neuroim2")
+  skip_if_not_installed("arrow")
 
   space <- neuroim2::NeuroSpace(c(2,2,1,2))
   arr <- array(seq_len(prod(c(2,2,1,2))), dim = c(2,2,1,2))
@@ -29,4 +30,20 @@ test_that("voxel extraction works", {
   expect_equal(length(df$bold[[1]]), 2)
   expect_true(all(df$x >= 0 & df$y >= 0 & df$z >= 0))
   expect_equal(sort(unique(df$zindex)), c(0L,1L,2L,3L))
+})
+
+test_that("arrow table is sorted by zindex", {
+  skip_if_not_installed("neuroim2")
+  skip_if_not_installed("arrow")
+
+  space <- neuroim2::NeuroSpace(c(2,2,1,2))
+  arr <- array(seq_len(prod(c(2,2,1,2))), dim = c(2,2,1,2))
+  nv <- neuroim2::DenseNeuroVec(arr, space)
+
+  res <- neurovec_to_fpar(nv, tempfile(), "sub01")
+  tbl <- res$arrow_table
+
+  expect_true(inherits(tbl, "Table"))
+  df <- as.data.frame(tbl)
+  expect_equal(df$zindex, sort(df$zindex))
 })


### PR DESCRIPTION
## Summary
- implement building and sorting Arrow table in `neurovec_to_fpar`
- extend neurovec tests to check Arrow table sorting

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683facc339d4832da196027f67086bd6