### PR TITLE
Implement core parquet writing

### DIFF
--- a/tests/testthat/test-neurovec_to_fpar.R
+++ b/tests/testthat/test-neurovec_to_fpar.R
@@ -47,3 +47,20 @@ test_that("arrow table is sorted by zindex", {
   df <- as.data.frame(tbl)
   expect_equal(df$zindex, sort(df$zindex))
 })
+
+test_that("parquet file written and sorted", {
+  skip_if_not_installed("neuroim2")
+  skip_if_not_installed("arrow")
+
+  space <- neuroim2::NeuroSpace(c(2,2,1,2))
+  arr <- array(seq_len(prod(c(2,2,1,2))), dim = c(2,2,1,2))
+  nv <- neuroim2::DenseNeuroVec(arr, space)
+
+  tmp <- tempfile(fileext = ".parquet")
+  neurovec_to_fpar(nv, tmp, "sub01")
+
+  expect_true(file.exists(tmp))
+  tbl <- arrow::read_parquet(tmp)
+  df <- as.data.frame(tbl)
+  expect_equal(df$zindex, sort(df$zindex))
+})


### PR DESCRIPTION
## Summary
- write `neurovec_to_fpar()` output using `arrow::write_parquet`
- document behaviour in `neurovec_to_fpar()`
- test that a parquet file is produced and sorted

## Testing
- `R -q -e "library(testthat); test_check('fmriarrow')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fada0e014832d93a07250b0fdfd8b