### PR TITLE
Implement spatial metadata storage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,8 @@ Depends:
 Imports:
     arrow (>= 10.0.0),
     dplyr (>= 1.0.0),
-    neuroim2 (>= 0.1.0)
+    neuroim2 (>= 0.1.0),
+    jsonlite
 Suggests:
     testthat (>= 3.0.0),
     knitr,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -4,6 +4,7 @@
 import(neuroim2)
 importFrom(arrow, write_parquet, read_parquet, open_dataset, Table)
 importFrom(dplyr, filter, arrange, select, mutate, left_join)
+importFrom(jsonlite, toJSON, fromJSON)
 
 # Export main functions (to be implemented)
 export(neurovec_to_fpar)

--- a/R/read_fpar_coords_roi.R
+++ b/R/read_fpar_coords_roi.R
@@ -1,0 +1,13 @@
+#' Read BOLD data for specified coordinates from a Parquet file
+#'
+#' This is a placeholder implementation that simply stops with a
+#' message. Full spatial querying will be implemented in later sprints.
+#'
+#' @param parquet_path Path to the Parquet file.
+#' @param x_coords Integer vector of 0-based x coordinates.
+#' @param y_coords Integer vector of 0-based y coordinates.
+#' @param z_coords Integer vector of 0-based z coordinates.
+#' @export
+read_fpar_coords_roi <- function(parquet_path, x_coords, y_coords, z_coords) {
+  stop("read_fpar_coords_roi() not implemented yet")
+}

--- a/R/read_fpar_metadata.R
+++ b/R/read_fpar_metadata.R
@@ -1,0 +1,16 @@
+#' Read fmriarrow metadata from a Parquet file
+#'
+#' This is a minimal helper that retrieves the JSON metadata stored
+#' by `neurovec_to_fpar()`.
+#'
+#' @param parquet_path Path to the Parquet file.
+#' @return A list with metadata fields.
+#' @export
+read_fpar_metadata <- function(parquet_path) {
+  tbl <- arrow::read_parquet(parquet_path, as_data_frame = FALSE)
+  md <- tbl$schema$metadata
+  if (is.null(md) || is.null(md$spatial_metadata)) {
+    return(list())
+  }
+  jsonlite::fromJSON(md$spatial_metadata)
+}

--- a/tests/testthat/test-neurovec_to_fpar.R
+++ b/tests/testthat/test-neurovec_to_fpar.R
@@ -64,3 +64,19 @@ test_that("parquet file written and sorted", {
   df <- as.data.frame(tbl)
   expect_equal(df$zindex, sort(df$zindex))
 })
+
+test_that("metadata stored and retrievable", {
+  skip_if_not_installed("neuroim2")
+  skip_if_not_installed("arrow")
+
+  space <- neuroim2::NeuroSpace(c(2,2,1,1))
+  arr <- array(1, dim = c(2,2,1,1))
+  nv <- neuroim2::DenseNeuroVec(arr, space)
+
+  tmp <- tempfile(fileext = ".parquet")
+  neurovec_to_fpar(nv, tmp, "sub01", reference_space = "test")
+
+  md <- read_fpar_metadata(tmp)
+  expect_equal(md$original_dimensions, c(2,2,1,1))
+  expect_equal(md$reference_space, "test")
+})


### PR DESCRIPTION
## Summary
- extract NeuroSpace metadata in `neurovec_to_fpar`
- embed metadata JSON in Parquet file
- expose helper `read_fpar_metadata` and stub for `read_fpar_coords_roi`
- test that metadata round trips

## Testing
- `R CMD check .` *(fails: command not found)*
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fae43cdec832dbf51dbea6fad3fc8