### PR TITLE
Add explicit Arrow schema and tests for neurovec_to_fpar

### DIFF
--- a/tests/testthat/test-neurovec_to_fpar.R
+++ b/tests/testthat/test-neurovec_to_fpar.R
@@ -79,6 +79,24 @@ test_that("arrow table has expected columns", {
   expect_equal(sort(tbl$schema$names), sort(expected))
 })
 
+test_that("arrow table has expected data types", {
+  skip_if_not_installed("neuroim2")
+  skip_if_not_installed("arrow")
+
+  space <- neuroim2::NeuroSpace(c(1,1,1,2))
+  arr <- array(1, dim = c(1,1,1,2))
+  nv <- neuroim2::DenseNeuroVec(arr, space)
+
+  res <- neurovec_to_fpar(nv, tempfile(), "sub01")
+  sch <- res$arrow_table$schema
+
+  expect_true(inherits(sch$GetFieldByName("x")$type, "UInt16Type"))
+  expect_true(inherits(sch$GetFieldByName("y")$type, "UInt16Type"))
+  expect_true(inherits(sch$GetFieldByName("z")$type, "UInt16Type"))
+  expect_true(inherits(sch$GetFieldByName("zindex")$type, "UInt32Type"))
+  expect_true(inherits(sch$GetFieldByName("bold")$type, "FixedSizeListType"))
+})
+
 test_that("parquet file written and sorted", {
   skip_if_not_installed("neuroim2")
   skip_if_not_installed("arrow")


### PR DESCRIPTION
## Summary
- define a detailed Arrow schema in `neurovec_to_fpar`
- construct arrow tables using that schema
- write Parquet files with a row group size of 4096
- test that the output arrow table uses the expected column types

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: Rscript not found)*
- `R CMD check .` *(fails: R not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fba5dce70832d90a4cf68706da2f1