### PR TITLE
Implement Sprint2-001 metadata helper

### DIFF
--- a/R/extract_neurospace_metadata.R
+++ b/R/extract_neurospace_metadata.R
@@ -1,0 +1,40 @@
+#' Extract metadata from a NeuroSpace object
+#'
+#' Internal helper used by [neurovec_to_fpar()] to construct the
+#' metadata list described in the Sprint 2 proposal.
+#'
+#' @param neuro_vec_obj A `neuroim2::NeuroVec` object.
+#' @param reference_space Optional reference space identifier.
+#' @param repetition_time Optional repetition time in seconds.
+#'
+#' @return A metadata list following the proposal specification.
+#' @noRd
+extract_neurospace_metadata <- function(neuro_vec_obj,
+                                        reference_space = NULL,
+                                        repetition_time = NULL) {
+  s <- neuroim2::space(neuro_vec_obj)
+  spacing_vec <- neuroim2::spacing(s)
+
+  list(
+    metadata_schema_version = "2.0.0",
+    source_info = list(
+      original_file = deparse(substitute(neuro_vec_obj)),
+      neuroim2_space_hash = digest::digest(s, algo = "sha256")
+    ),
+    spatial_properties = list(
+      original_dimensions = as.integer(dim(s)),
+      voxel_size_mm = as.numeric(spacing_vec[1:min(3, length(spacing_vec))]),
+      affine_matrix = as.matrix(neuroim2::trans(s)),
+      reference_space = reference_space %||% "unknown",
+      coordinate_convention = "0-based RAS"
+    ),
+    acquisition_properties = list(
+      repetition_time_s = repetition_time %||% NA_real_,
+      timepoint_count = as.integer(dim(neuro_vec_obj)[4])
+    ),
+    data_integrity = list(
+      voxel_count = as.integer(prod(dim(s)[1:3])),
+      bold_value_range = c(NA_real_, NA_real_)
+    )
+  )
+}

--- a/R/neurovec_to_fpar.R
+++ b/R/neurovec_to_fpar.R
@@ -69,32 +69,11 @@ neurovec_to_fpar <- function(neuro_vec_obj, output_parquet_path,
     stop("NeuroVec must have at least 4 dimensions (3 spatial + 1 temporal)")
   }
 
-  # Extract metadata from NeuroSpace (CORE-007)
-  spacing_vec <- neuroim2::spacing(space_obj)
-  affine_matrix <- neuroim2::trans(space_obj)
-  
-  # Create comprehensive metadata structure per Sprint 2 specification
-  metadata <- list(
-    metadata_schema_version = "2.0.0",
-    source_info = list(
-      original_file = deparse(substitute(neuro_vec_obj)),
-      neuroim2_space_hash = digest::digest(space_obj, algo = "sha256")
-    ),
-    spatial_properties = list(
-      original_dimensions = as.integer(dims),
-      voxel_size_mm = as.numeric(spacing_vec[1:min(3, length(spacing_vec))]),
-      affine_matrix = as.matrix(affine_matrix),
-      reference_space = reference_space %||% "unknown",
-      coordinate_convention = "0-based RAS"
-    ),
-    acquisition_properties = list(
-      repetition_time_s = repetition_time %||% NA_real_,
-      timepoint_count = as.integer(neuro_vec_dims[4])
-    ),
-    data_integrity = list(
-      voxel_count = as.integer(prod(dims[1:3])),
-      bold_value_range = c(NA_real_, NA_real_)  # Will be computed during iteration
-    )
+  # Construct metadata structure per Sprint 2 specification
+  metadata <- extract_neurospace_metadata(
+    neuro_vec_obj,
+    reference_space = reference_space,
+    repetition_time = repetition_time
   )
 
   # Initialize voxel iteration

--- a/data-raw/sprint2.md
+++ b/data-raw/sprint2.md
@@ -58,6 +58,14 @@
 - Metadata structure matches proposal specification
 - Function handles missing/optional metadata gracefully
 
+### Implementation
+
+The package now includes an internal helper `extract_neurospace_metadata()` that
+builds the metadata list described above. `neurovec_to_fpar()` calls this helper
+and updates the `bold_value_range` after iterating over voxels. The function also
+accepts the new `reference_space` and `repetition_time` parameters and embeds all
+fields in the returned metadata structure.
+
 ### **`[SPRINT2-002]` Embed Metadata into Parquet File**
 
 **Purpose:** Store the extracted metadata as Parquet schema metadata for later retrieval.


### PR DESCRIPTION
## Summary
- add internal `extract_neurospace_metadata()` utility
- refactor `neurovec_to_fpar()` to use helper
- document implementation of Sprint2-001 in `sprint2.md`

## Testing
- `Rscript -e '1+1'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fbb50e86c832da5887269b460ccbc