### PR TITLE
Implement sprint2 zindex helpers

### DIFF
--- a/R/coords_to_zindex_range.R
+++ b/R/coords_to_zindex_range.R
@@ -14,16 +14,27 @@
 #' @export
 coords_to_zindex_range <- function(x_range, y_range, z_range,
                                    max_coord_bits = 10) {
-  x_range <- validate_coordinate_range(x_range, "x_range", max_coord_bits)
-  y_range <- validate_coordinate_range(y_range, "y_range", max_coord_bits)
-  z_range <- validate_coordinate_range(z_range, "z_range", max_coord_bits)
+  # Normalize coordinate ranges to length 2
+  x_range <- normalize_coord_range(x_range)
+  y_range <- normalize_coord_range(y_range)
+  z_range <- normalize_coord_range(z_range)
+
+  # Ensure coordinates fall within allowed bounds
+  max_coord <- (2^max_coord_bits) - 1L
+  validate_coord_bounds(c(x_range, y_range, z_range), max_coord)
 
   corners <- expand.grid(
     x = c(x_range[1], x_range[2]),
     y = c(y_range[1], y_range[2]),
     z = c(z_range[1], z_range[2])
   )
-  zindices <- compute_zindex(corners$x, corners$y, corners$z,
-                             max_coord_bits = max_coord_bits)
+
+  zindices <- compute_zindex(
+    corners$x,
+    corners$y,
+    corners$z,
+    max_coord_bits = max_coord_bits
+  )
+
   list(min_zindex = min(zindices), max_zindex = max(zindices))
 }

--- a/R/read_fpar_zindex_range.R
+++ b/R/read_fpar_zindex_range.R
@@ -26,9 +26,10 @@ read_fpar_zindex_range <- function(parquet_path, min_zindex, max_zindex, columns
     columns <- schema_cols
   }
 
-  query <- ds |>
+  result <- ds |>
     dplyr::filter(zindex >= min_zindex & zindex <= max_zindex) |>
-    dplyr::select(dplyr::all_of(columns))
+    dplyr::select(dplyr::all_of(columns)) |>
+    dplyr::compute()
 
-  as.data.frame(dplyr::collect(query, as_data_frame = FALSE))
+  result
 }

--- a/R/utils_validation.R
+++ b/R/utils_validation.R
@@ -63,6 +63,34 @@ validate_zindex_range <- function(min_zindex, max_zindex) {
   invisible(TRUE)
 }
 
+# Normalize a coordinate range to length 2
+#
+# Helper for [coords_to_zindex_range()]. Accepts either a single
+# coordinate or a two element vector and returns an integer vector of
+# length 2.
+#' @noRd
+normalize_coord_range <- function(range) {
+  if (length(range) == 1) {
+    range <- c(range, range)
+  }
+  if (length(range) != 2) {
+    stop("coordinate range must be length 1 or 2")
+  }
+  as.integer(range)
+}
+
+# Validate that coordinates lie within 0..max_coord
+#
+# Used by [coords_to_zindex_range()] to guard against out-of-bounds
+# queries.
+#' @noRd
+validate_coord_bounds <- function(ranges, max_coord) {
+  if (any(ranges < 0L) || any(ranges > max_coord)) {
+    stop("coordinate values exceed bounds [0, ", max_coord, "]")
+  }
+  invisible(TRUE)
+}
+
 #' Null-coalescing operator
 #' @param x First value
 #' @param y Second value (returned if x is NULL)

--- a/tests/testthat/test-read_fpar_coords_roi.R
+++ b/tests/testthat/test-read_fpar_coords_roi.R
@@ -16,23 +16,26 @@ neurovec_to_fpar(nv, tmp, "sub01")
 test_that("basic coordinate ROI query", {
   # Query a single voxel
   result <- read_fpar_coords_roi(tmp, c(1, 1), c(1, 1), c(1, 1))
-  expect_equal(nrow(result), 1)
-  expect_equal(result$x[1], 1)
-  expect_equal(result$y[1], 1)
-  expect_equal(result$z[1], 1)
+  df <- as.data.frame(result)
+  expect_equal(nrow(df), 1)
+  expect_equal(df$x[1], 1)
+  expect_equal(df$y[1], 1)
+  expect_equal(df$z[1], 1)
 })
 
 test_that("multi-voxel coordinate ROI query", {
   # Query a 2x2x1 region
   result <- read_fpar_coords_roi(tmp, c(0, 1), c(0, 1), c(0, 0))
-  expect_equal(nrow(result), 4)
-  expect_true(all(result$x %in% c(0, 1)))
-  expect_true(all(result$y %in% c(0, 1)))
-  expect_true(all(result$z == 0))
+  df <- as.data.frame(result)
+  expect_equal(nrow(df), 4)
+  expect_true(all(df$x %in% c(0, 1)))
+  expect_true(all(df$y %in% c(0, 1)))
+  expect_true(all(df$z == 0))
 })
 
 test_that("out-of-bounds coordinates fail gracefully", {
   # Query beyond the image bounds
   result <- read_fpar_coords_roi(tmp, c(10, 15), c(10, 15), c(10, 15))
-  expect_equal(nrow(result), 0)
+  df <- as.data.frame(result)
+  expect_equal(nrow(df), 0)
 })

--- a/tests/testthat/test-read_fpar_zindex_range.R
+++ b/tests/testthat/test-read_fpar_zindex_range.R
@@ -15,14 +15,16 @@ neurovec_to_fpar(nv, tmp, "sub01")
 
 test_that("basic zindex range query", {
   result <- read_fpar_zindex_range(tmp, 0, 1)
-  expect_equal(nrow(result), 2)
-  expect_true(all(result$zindex %in% c(0, 1)))
+  df <- as.data.frame(result)
+  expect_equal(nrow(df), 2)
+  expect_true(all(df$zindex %in% c(0, 1)))
 })
 
 test_that("single zindex query", {
   result <- read_fpar_zindex_range(tmp, 2, 2)
-  expect_equal(nrow(result), 1)
-  expect_equal(result$zindex[1], 2)
+  df <- as.data.frame(result)
+  expect_equal(nrow(df), 1)
+  expect_equal(df$zindex[1], 2)
 })
 
 test_that("invalid column names trigger error", {
@@ -31,7 +33,8 @@ test_that("invalid column names trigger error", {
 
 test_that("empty range returns empty result", {
   result <- read_fpar_zindex_range(tmp, 100, 200)
-  expect_equal(nrow(result), 0)
+  df <- as.data.frame(result)
+  expect_equal(nrow(df), 0)
 })
 
 test_that("invalid zindex range fails", {


### PR DESCRIPTION
## Summary
- add `normalize_coord_range()` and `validate_coord_bounds()` helpers
- update `coords_to_zindex_range()` to normalise ranges and validate bounds
- return Arrow tables from `read_fpar_zindex_range()`
- adjust ROI query and zindex range tests for Arrow table output

## Testing
- `devtools::test()` *(fails: `R` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683fbd4e1a70832da2af159602de647d