### PR TITLE
Implement SPRINT2-006 coordinate ROI query

### DIFF
--- a/R/read_fpar_coords_roi.R
+++ b/R/read_fpar_coords_roi.R
@@ -9,12 +9,17 @@
 #' @param z_range Vector of length 1 or 2 giving the z-coordinate range (0-based, inclusive).
 #' @param columns Optional character vector of columns to return. If `NULL`, all
 #'   columns are returned.
+#' @param exact If `TRUE` (default), coordinates are filtered exactly after an
+#'   initial Z-index range search. When `FALSE`, only the coarse Z-index
+#'   filtering is applied which may include voxels outside the requested cuboid
+#'   but can be faster for large ROIs.
 #' @param max_coord_bits Maximum number of bits per coordinate (default: 10).
 #'
 #' @return A data.frame containing the filtered rows.
 #' @export
 read_fpar_coords_roi <- function(parquet_path, x_range, y_range, z_range,
-                                 columns = NULL, max_coord_bits = 10) {
+                                 columns = NULL, exact = TRUE,
+                                 max_coord_bits = 10) {
   validate_parquet_path(parquet_path)
 
   # Validate and normalize coordinate ranges
@@ -25,6 +30,30 @@ read_fpar_coords_roi <- function(parquet_path, x_range, y_range, z_range,
   # Convert coordinate ranges to Z-index range
   zindex_range <- coords_to_zindex_range(x_range, y_range, z_range, max_coord_bits)
 
-  # Query using Z-index range
-  read_fpar_zindex_range(parquet_path, zindex_range$min_zindex, zindex_range$max_zindex, columns)
+  query_cols <- columns
+  if (exact) {
+    query_cols <- unique(c(query_cols, "x", "y", "z"))
+  }
+
+  data <- read_fpar_zindex_range(
+    parquet_path,
+    zindex_range$min_zindex,
+    zindex_range$max_zindex,
+    query_cols
+  )
+
+  if (exact) {
+    data <- data |>
+      dplyr::filter(
+        x >= x_range[1] & x <= x_range[2] &
+          y >= y_range[1] & y <= y_range[2] &
+          z >= z_range[1] & z <= z_range[2]
+      )
+
+    if (!is.null(columns)) {
+      data <- data |> dplyr::select(dplyr::all_of(columns))
+    }
+  }
+
+  data
 }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ neurovec_to_fpar(nv, outfile, subject_id = "subj01")
 md <- read_fpar_metadata(outfile)
 
 # query a small ROI (0-based coordinates)
-roi <- read_fpar_coords_roi(outfile, c(0, 1), c(0, 1), c(0, 0))
+roi <- read_fpar_coords_roi(outfile, c(0, 1), c(0, 1), c(0, 0), exact = TRUE)
 ```
 
 Coordinates stored in the Parquet file are **0-based**, whereas

--- a/tests/testthat/test-read_fpar_coords_roi.R
+++ b/tests/testthat/test-read_fpar_coords_roi.R
@@ -15,7 +15,7 @@ neurovec_to_fpar(nv, tmp, "sub01")
 
 test_that("basic coordinate ROI query", {
   # Query a single voxel
-  result <- read_fpar_coords_roi(tmp, c(1, 1), c(1, 1), c(1, 1))
+  result <- read_fpar_coords_roi(tmp, c(1, 1), c(1, 1), c(1, 1), exact = TRUE)
   df <- as.data.frame(result)
   expect_equal(nrow(df), 1)
   expect_equal(df$x[1], 1)
@@ -25,7 +25,7 @@ test_that("basic coordinate ROI query", {
 
 test_that("multi-voxel coordinate ROI query", {
   # Query a 2x2x1 region
-  result <- read_fpar_coords_roi(tmp, c(0, 1), c(0, 1), c(0, 0))
+  result <- read_fpar_coords_roi(tmp, c(0, 1), c(0, 1), c(0, 0), exact = TRUE)
   df <- as.data.frame(result)
   expect_equal(nrow(df), 4)
   expect_true(all(df$x %in% c(0, 1)))
@@ -35,7 +35,21 @@ test_that("multi-voxel coordinate ROI query", {
 
 test_that("out-of-bounds coordinates fail gracefully", {
   # Query beyond the image bounds
-  result <- read_fpar_coords_roi(tmp, c(10, 15), c(10, 15), c(10, 15))
+  result <- read_fpar_coords_roi(tmp, c(10, 15), c(10, 15), c(10, 15), exact = TRUE)
   df <- as.data.frame(result)
   expect_equal(nrow(df), 0)
+})
+
+test_that("column selection works with exact filtering", {
+  result <- read_fpar_coords_roi(tmp, c(0, 1), c(0, 1), c(0, 0),
+                                 columns = "bold", exact = TRUE)
+  df <- as.data.frame(result)
+  expect_equal(names(df), "bold")
+  expect_equal(nrow(df), 4)
+})
+
+test_that("approximate filtering returns at least as many rows", {
+  exact_res <- read_fpar_coords_roi(tmp, c(0, 1), c(0, 1), c(0, 0), exact = TRUE)
+  approx_res <- read_fpar_coords_roi(tmp, c(0, 1), c(0, 1), c(0, 0), exact = FALSE)
+  expect_true(nrow(as.data.frame(approx_res)) >= nrow(as.data.frame(exact_res)))
 })


### PR DESCRIPTION
## Summary
- implement two-stage filtering in `read_fpar_coords_roi()` with optional exact mode
- update README example for the new argument
- expand tests for `read_fpar_coords_roi()`

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fbe4f8bf8832d8a97581d6a2669b1