### PR TITLE
Add coordinate and max bit validation

### DIFF
--- a/R/compute_hindex.R
+++ b/R/compute_hindex.R
@@ -2,12 +2,13 @@
 #'
 #' This initial implementation approximates a 3D Hilbert curve
 #' by interleaving Gray-coded coordinate bits. Coordinates must
-#' be non-negative integers and less than 2^`max_coord_bits`.
+#' be non-negative integer-valued and less than 2^`max_coord_bits`.
 #'
 #' @param x,y,z Integer vectors of equal length with 0-based
 #'   voxel coordinates.
 #' @param max_coord_bits Maximum number of bits used to represent
-#'   each coordinate (default 10).
+#'   each coordinate (default 10). Must be a positive integer less
+#'   than 31.
 #'
 #' @return Integer vector of Hilbert indices.
 #' @export
@@ -15,9 +16,18 @@ compute_hindex <- function(x, y, z, max_coord_bits = 10) {
   if (length(x) != length(y) || length(y) != length(z)) {
     stop("x, y and z must have the same length")
   }
+  if (!all(x == as.integer(x)) || !all(y == as.integer(y)) || !all(z == as.integer(z))) {
+    stop("coordinates must be integer-valued")
+  }
   if (any(x < 0 | y < 0 | z < 0)) {
     stop("coordinates must be non-negative")
   }
+  if (!is.numeric(max_coord_bits) || length(max_coord_bits) != 1 ||
+      is.na(max_coord_bits) || max_coord_bits != as.integer(max_coord_bits) ||
+      max_coord_bits <= 0 || max_coord_bits >= 31) {
+    stop("max_coord_bits must be a single positive integer less than 31")
+  }
+  max_coord_bits <- as.integer(max_coord_bits)
   limit <- bitwShiftL(1L, max_coord_bits)
   if (any(x >= limit | y >= limit | z >= limit)) {
     stop("coordinates exceed range defined by max_coord_bits")

--- a/R/compute_zindex.R
+++ b/R/compute_zindex.R
@@ -2,12 +2,13 @@
 #'
 #' Interleaves bits of the x, y and z coordinates to create a
 #' 32-bit unsigned integer Morton code. Coordinates must be
-#' non-negative integers and less than 2^`max_coord_bits`.
+#' non-negative integer-valued and less than 2^`max_coord_bits`.
 #'
 #' @param x,y,z Integer vectors of equal length with 0-based
 #'   voxel coordinates.
 #' @param max_coord_bits Maximum number of bits used to represent
-#'   each coordinate (default 10).
+#'   each coordinate (default 10). Must be a positive integer less
+#'   than 31.
 #'
 #' @return Integer vector of the same length as `x` with the
 #'   computed Morton codes.
@@ -16,9 +17,18 @@ compute_zindex <- function(x, y, z, max_coord_bits = 10) {
   if (length(x) != length(y) || length(y) != length(z)) {
     stop("x, y and z must have the same length")
   }
+  if (!all(x == as.integer(x)) || !all(y == as.integer(y)) || !all(z == as.integer(z))) {
+    stop("coordinates must be integer-valued")
+  }
   if (any(x < 0 | y < 0 | z < 0)) {
     stop("coordinates must be non-negative")
   }
+  if (!is.numeric(max_coord_bits) || length(max_coord_bits) != 1 ||
+      is.na(max_coord_bits) || max_coord_bits != as.integer(max_coord_bits) ||
+      max_coord_bits <= 0 || max_coord_bits >= 31) {
+    stop("max_coord_bits must be a single positive integer less than 31")
+  }
+  max_coord_bits <- as.integer(max_coord_bits)
   limit <- bitwShiftL(1L, max_coord_bits)
   if (any(x >= limit | y >= limit | z >= limit)) {
     stop("coordinates exceed range defined by max_coord_bits")

--- a/tests/testthat/test-compute_hindex.R
+++ b/tests/testthat/test-compute_hindex.R
@@ -18,5 +18,8 @@ test_that("vectorized input works", {
 test_that("input validation", {
   expect_error(compute_hindex(-1, 0, 0))
   expect_error(compute_hindex(0, 0, 1024, max_coord_bits = 10))
+  expect_error(compute_hindex(0.5, 0, 0))
+  expect_error(compute_hindex(0, 0, 0, max_coord_bits = 0))
+  expect_error(compute_hindex(0, 0, 0, max_coord_bits = 31))
 })
 

--- a/tests/testthat/test-compute_zindex.R
+++ b/tests/testthat/test-compute_zindex.R
@@ -20,4 +20,7 @@ test_that("vectorized input works", {
 test_that("input validation", {
   expect_error(compute_zindex(-1, 0, 0))
   expect_error(compute_zindex(0, 0, 1024, max_coord_bits = 10))
+  expect_error(compute_zindex(0.5, 0, 0))
+  expect_error(compute_zindex(0, 0, 0, max_coord_bits = 0))
+  expect_error(compute_zindex(0, 0, 0, max_coord_bits = 31))
 })


### PR DESCRIPTION
## Summary
- enforce integer-valued coordinates and max_coord_bits range in `compute_hindex`
- mirror the same checks in `compute_zindex`
- document new constraints
- extend tests for these validations

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840051e6fb4832db408f8c3ba146a7a