### PR TITLE
Simplify coords_to_zindex_range

### DIFF
--- a/R/coords_to_zindex_range.R
+++ b/R/coords_to_zindex_range.R
@@ -23,18 +23,19 @@ coords_to_zindex_range <- function(x_range, y_range, z_range,
   max_coord <- (2^max_coord_bits) - 1L
   validate_coord_bounds(c(x_range, y_range, z_range), max_coord)
 
-  corners <- expand.grid(
-    x = c(x_range[1], x_range[2]),
-    y = c(y_range[1], y_range[2]),
-    z = c(z_range[1], z_range[2])
-  )
-
-  zindices <- compute_zindex(
-    corners$x,
-    corners$y,
-    corners$z,
+  min_z <- compute_zindex(
+    x_range[1],
+    y_range[1],
+    z_range[1],
     max_coord_bits = max_coord_bits
   )
 
-  list(min_zindex = min(zindices), max_zindex = max(zindices))
+  max_z <- compute_zindex(
+    x_range[2],
+    y_range[2],
+    z_range[2],
+    max_coord_bits = max_coord_bits
+  )
+
+  list(min_zindex = min_z, max_zindex = max_z)
 }

--- a/tests/testthat/test-coords_to_zindex_range.R
+++ b/tests/testthat/test-coords_to_zindex_range.R
@@ -13,3 +13,28 @@ test_that("small cuboid", {
   expect_equal(zr$min_zindex, 0L)
   expect_equal(zr$max_zindex, 3L)
 })
+
+test_that("new implementation matches expand.grid approach", {
+  x_range <- c(1L, 3L)
+  y_range <- c(2L, 4L)
+  z_range <- c(0L, 1L)
+
+  # Expected result using previous expand.grid logic
+  corners <- expand.grid(
+    x = c(x_range[1], x_range[2]),
+    y = c(y_range[1], y_range[2]),
+    z = c(z_range[1], z_range[2])
+  )
+
+  zindices <- compute_zindex(
+    corners$x,
+    corners$y,
+    corners$z
+  )
+
+  expected <- list(min_zindex = min(zindices), max_zindex = max(zindices))
+
+  result <- coords_to_zindex_range(x_range, y_range, z_range)
+
+  expect_equal(result, expected)
+})


### PR DESCRIPTION
## Summary
- simplify `coords_to_zindex_range()` by removing `expand.grid()`
- compute min and max Z-indices directly
- verify new implementation matches previous behaviour

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840056459c4832d832c21f291b9c5ab