### PR TITLE
Ensure voxel_size_mm length

### DIFF
--- a/R/extract_neurospace_metadata.R
+++ b/R/extract_neurospace_metadata.R
@@ -7,13 +7,18 @@
 #' @param reference_space Optional reference space identifier.
 #' @param repetition_time Optional repetition time in seconds.
 #'
-#' @return A metadata list following the proposal specification.
+#' @return A metadata list following the proposal specification. The
+#'   `voxel_size_mm` field always contains exactly three numeric values;
+#'   if the source `NeuroSpace` has fewer spacing elements they are
+#'   recycled to length three.
 #' @noRd
 extract_neurospace_metadata <- function(neuro_vec_obj,
                                         reference_space = NULL,
                                         repetition_time = NULL) {
   s <- neuroim2::space(neuro_vec_obj)
   spacing_vec <- neuroim2::spacing(s)
+  # Recycle or truncate to always return a three-element spacing vector
+  spacing_vec <- rep(spacing_vec, length.out = 3)
 
   list(
     metadata_schema_version = "2.0.0",
@@ -23,7 +28,7 @@ extract_neurospace_metadata <- function(neuro_vec_obj,
     ),
     spatial_properties = list(
       original_dimensions = as.integer(dim(s)),
-      voxel_size_mm = as.numeric(spacing_vec[1:min(3, length(spacing_vec))]),
+      voxel_size_mm = as.numeric(spacing_vec),
       affine_matrix = as.matrix(neuroim2::trans(s)),
       reference_space = reference_space %||% "unknown",
       coordinate_convention = "0-based RAS"

--- a/tests/testthat/test-extract_neurospace_metadata.R
+++ b/tests/testthat/test-extract_neurospace_metadata.R
@@ -1,0 +1,8 @@
+test_that("voxel_size_mm always length three", {
+  skip_if_not_installed("neuroim2")
+  space <- neuroim2::NeuroSpace(dim = c(2, 2, 2, 1), spacing = c(2))
+  arr <- array(1, dim = c(2, 2, 2, 1))
+  nv <- neuroim2::DenseNeuroVec(arr, space)
+  md <- fmriarrow:::extract_neurospace_metadata(nv)
+  expect_equal(length(md$spatial_properties$voxel_size_mm), 3)
+})


### PR DESCRIPTION
## Summary
- recycle `spacing_vec` so `voxel_size_mm` always has three elements
- clarify this behaviour in the metadata helper docs
- test that short spacing vectors return `voxel_size_mm` of length three

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840058a8f24832dbbf27d71f1ea73aa