### PR TITLE
Add cleanup for performance sanity temp file

### DIFF
--- a/R/performance_sanity.R
+++ b/R/performance_sanity.R
@@ -23,6 +23,7 @@ performance_sanity_check <- function(neuro_vec_obj,
   }
 
   tmp <- tempfile(fileext = ".parquet")
+  on.exit(unlink(tmp), add = TRUE)
 
   t_conv <- system.time(
     neurovec_to_fpar(neuro_vec_obj, tmp, "perfsubj")


### PR DESCRIPTION
## Summary
- guarantee removal of tmp file in `performance_sanity_check` using `on.exit`

## Testing
- `R CMD build .` *(fails: R missing)*

------
https://chatgpt.com/codex/tasks/task_e_684005e7f240832d9ad55f4d7bdb6dd7