### PR TITLE
Fix roxygen return for read_fpar_coords_roi

### DIFF
--- a/R/read_fpar_coords_roi.R
+++ b/R/read_fpar_coords_roi.R
@@ -15,7 +15,7 @@
 #'   but can be faster for large ROIs.
 #' @param max_coord_bits Maximum number of bits per coordinate (default: 10).
 #'
-#' @return A data.frame containing the filtered rows.
+#' @return An Arrow Table containing the filtered rows.
 #' @export
 read_fpar_coords_roi <- function(parquet_path, x_range, y_range, z_range,
                                  columns = NULL, exact = TRUE,


### PR DESCRIPTION
## Summary
- update the documentation for `read_fpar_coords_roi` to specify that it
  returns an Arrow Table

## Testing
- `roxygen2::roxygenise()` *(fails: R not installed)*
- `devtools::test()` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684005ef588c832dad973b24af537b9e