### PR TITLE
Refactor coordinate ROI query for lazy filtering

### DIFF
--- a/R/read_fpar_coords_roi.R
+++ b/R/read_fpar_coords_roi.R
@@ -30,30 +30,42 @@ read_fpar_coords_roi <- function(parquet_path, x_range, y_range, z_range,
   # Convert coordinate ranges to Z-index range
   zindex_range <- coords_to_zindex_range(x_range, y_range, z_range, max_coord_bits)
 
+  ds <- arrow::open_dataset(parquet_path)
+  schema_cols <- ds$schema$names
+  if (!is.null(columns)) {
+    if (!all(columns %in% schema_cols)) {
+      missing <- setdiff(columns, schema_cols)
+      stop("Invalid column names: ", paste(missing, collapse = ", "))
+    }
+  } else {
+    columns <- schema_cols
+  }
+
   query_cols <- columns
   if (exact) {
     query_cols <- unique(c(query_cols, "x", "y", "z"))
   }
 
-  data <- read_fpar_zindex_range(
-    parquet_path,
-    zindex_range$min_zindex,
-    zindex_range$max_zindex,
-    query_cols
-  )
+  query <- ds |>
+    dplyr::filter(zindex >= zindex_range$min_zindex &
+                    zindex <= zindex_range$max_zindex)
 
   if (exact) {
-    data <- data |>
+    query <- query |>
       dplyr::filter(
         x >= x_range[1] & x <= x_range[2] &
           y >= y_range[1] & y <= y_range[2] &
           z >= z_range[1] & z <= z_range[2]
       )
-
-    if (!is.null(columns)) {
-      data <- data |> dplyr::select(dplyr::all_of(columns))
-    }
   }
 
-  data
+  query <- query |> dplyr::select(dplyr::all_of(query_cols))
+
+  result <- dplyr::collect(query)
+
+  if (exact && !is.null(columns)) {
+    result <- result |> dplyr::select(dplyr::all_of(columns))
+  }
+
+  result
 }

--- a/R/read_fpar_zindex_range.R
+++ b/R/read_fpar_zindex_range.R
@@ -8,10 +8,15 @@
 #' @param max_zindex Maximum Z-index (inclusive).
 #' @param columns Optional character vector of columns to return. If `NULL`, all
 #'   columns are returned.
+#' @param compute If `TRUE` (default), the query is materialized with
+#'   `dplyr::compute()` before returning. Set to `FALSE` to return a lazy
+#'   query suitable for further filtering.
 #'
-#' @return An Arrow Table containing the filtered rows.
+#' @return An Arrow Table when `compute = TRUE` or a lazy query when
+#'   `compute = FALSE`.
 #' @export
-read_fpar_zindex_range <- function(parquet_path, min_zindex, max_zindex, columns = NULL) {
+read_fpar_zindex_range <- function(parquet_path, min_zindex, max_zindex,
+                                   columns = NULL, compute = TRUE) {
   validate_parquet_path(parquet_path)
   validate_zindex_range(min_zindex, max_zindex)
 
@@ -26,10 +31,13 @@ read_fpar_zindex_range <- function(parquet_path, min_zindex, max_zindex, columns
     columns <- schema_cols
   }
 
-  result <- ds |>
+  query <- ds |>
     dplyr::filter(zindex >= min_zindex & zindex <= max_zindex) |>
-    dplyr::select(dplyr::all_of(columns)) |>
-    dplyr::compute()
+    dplyr::select(dplyr::all_of(columns))
 
-  result
+  if (isTRUE(compute)) {
+    query <- dplyr::compute(query)
+  }
+
+  query
 }


### PR DESCRIPTION
## Summary
- refactor `read_fpar_coords_roi()` to apply all filters lazily
- support returning a lazy query from `read_fpar_zindex_range()` via a new `compute` argument

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684005f03dc8832d9418afcba31fd621