### PR TITLE
Handle raw schema metadata in read_fpar_metadata

### DIFF
--- a/R/read_fpar_metadata.R
+++ b/R/read_fpar_metadata.R
@@ -42,9 +42,16 @@ read_fpar_metadata <- function(parquet_path) {
 
       if (length(schema_metadata) > 0) {
         if (!is.null(schema_metadata$spatial_metadata)) {
-          parsed_metadata <- jsonlite::fromJSON(schema_metadata$spatial_metadata)
+          spatial_md <- schema_metadata$spatial_metadata
+          if (is.raw(spatial_md)) {
+            spatial_md <- rawToChar(spatial_md)
+          }
+          parsed_metadata <- jsonlite::fromJSON(spatial_md)
         } else {
           parsed_metadata <- lapply(schema_metadata, function(x) {
+            if (is.raw(x)) {
+              x <- rawToChar(x)
+            }
             tryCatch({
               val <- jsonlite::fromJSON(x)
               if (is.character(val) && length(val) == 1) val else val

--- a/tests/testthat/test-read_fpar_metadata.R
+++ b/tests/testthat/test-read_fpar_metadata.R
@@ -31,3 +31,17 @@ test_that("warning for non-standard extension", {
   file.copy(tmp, tmp2)
   expect_warning(read_fpar_metadata(tmp2), "File extension should")
 })
+
+test_that("raw schema metadata parsed", {
+  skip_if_not_installed("arrow")
+
+  json_md <- jsonlite::toJSON(list(test_value = 123), auto_unbox = TRUE)
+  tbl <- arrow::arrow_table(dummy = 1L)
+  sch <- tbl$schema$WithMetadata(list(spatial_metadata = charToRaw(json_md)))
+  tbl <- tbl$with_schema(sch)
+  raw_tmp <- tempfile(fileext = ".parquet")
+  arrow::write_parquet(tbl, raw_tmp)
+
+  md_raw <- read_fpar_metadata(raw_tmp)
+  expect_equal(md_raw$test_value, 123)
+})


### PR DESCRIPTION
## Summary
- support raw vectors in `read_fpar_metadata()`
- add test for parsing raw metadata values

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*
- `Rscript -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684005f76c80832d897c58e7d36d885a