### PR TITLE
Add hilbert adjacency checks

### DIFF
--- a/tests/testthat/test-compute_hindex.R
+++ b/tests/testthat/test-compute_hindex.R
@@ -37,16 +37,19 @@ test_that("input validation", {
 })
 
 test_that("adjacent indices are neighbors", {
-  skip("Hilbert curve neighbor property test needs review")
-  nbits <- 4
-  n <- 2^nbits
-  coords <- expand.grid(x = 0:(n - 1), y = 0:(n - 1), z = 0:(n - 1))
-  idx <- compute_hindex_cpp(coords$x, coords$y, coords$z, nbits)
-  sorted <- coords[order(idx), ]
-  dists <- sapply(2:nrow(sorted), function(i) {
-    sum(abs(sorted[i, ] - sorted[i - 1, ]))
-  })
-  expect_true(all(dists == 1))
+  for (nbits in 2:5) {
+    n <- 2^nbits
+    coords <- expand.grid(x = 0:(n - 1), y = 0:(n - 1), z = 0:(n - 1))
+    idx <- compute_hindex_cpp(coords$x, coords$y, coords$z, nbits)
+
+    expect_equal(length(unique(idx)), length(idx))
+
+    sorted <- coords[order(idx), ]
+    dists <- sapply(2:nrow(sorted), function(i) {
+      sum(abs(sorted[i, ] - sorted[i - 1, ]))
+    })
+    expect_true(all(dists == 1))
+  }
 })
 
 test_that("single point wrapper works", {


### PR DESCRIPTION
## Summary
- verify hilbert indices are unique and adjacent for `nbits` 2–5

## Testing
- `R -q -e 'devtools::test()'` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68420f4c9c00832d87558ae85e08e7f3