### PR TITLE
Add R fallback for Hilbert index

### DIFF
--- a/R/compute_hindex.R
+++ b/R/compute_hindex.R
@@ -18,7 +18,9 @@
 #' @return Hilbert indices as either numeric or character vector depending on
 #'   `as_character`.
 #' @export
-compute_hindex <- function(x, y, z, max_coord_bits = 10, as_character = FALSE) {
+compute_hindex <- function(x, y, z, max_coord_bits = 10, as_character = FALSE,
+                           implementation = c("cpp", "R")) {
+  implementation <- match.arg(implementation)
   max_coord_bits <- validate_max_coord_bits(max_coord_bits)
   if (max_coord_bits > 20L) {
     stop("max_coord_bits must be between 1 and 20")
@@ -39,6 +41,72 @@ compute_hindex <- function(x, y, z, max_coord_bits = 10, as_character = FALSE) {
   x <- as.integer(x)
   y <- as.integer(y)
   z <- as.integer(z)
-  compute_hindex_cpp(x, y, z, max_coord_bits, as_character)
+  use_cpp <- identical(implementation, "cpp") &&
+    exists("compute_hindex_cpp", mode = "function")
+  if (use_cpp) {
+    compute_hindex_cpp(x, y, z, max_coord_bits, as_character)
+  } else {
+    compute_hindex_reference(x, y, z, max_coord_bits, as_character)
+  }
+}
+
+# Internal helper: rotate and flip a quadrant according to Hilbert rules
+hilbert_rotate <- function(n, x, y, z, rx, ry, rz) {
+  if (rz == 0L) {
+    if (ry == 0L) {
+      if (rx == 1L) {
+        x <- n - 1L - x
+        y <- n - 1L - y
+      }
+      tmp <- x; x <- y; y <- tmp
+    } else {
+      if (rx == 0L) {
+        x <- n - 1L - x
+        y <- n - 1L - y
+      }
+    }
+    tmp <- y; y <- z; z <- tmp
+  } else {
+    if (ry == 1L) {
+      if (rx == 1L) {
+        x <- n - 1L - x
+        y <- n - 1L - y
+      }
+      tmp <- x; x <- y; y <- tmp
+    } else {
+      if (rx == 0L) {
+        x <- n - 1L - x
+        y <- n - 1L - y
+      }
+    }
+  }
+  c(x, y, z)
+}
+
+# Reference implementation of the Hilbert index in pure R
+hilbert3D_single_ref <- function(x, y, z, nbits) {
+  idx <- 0
+  n <- bitwShiftL(1L, nbits)
+  for (i in seq(from = nbits - 1L, to = 0L)) {
+    rx <- bitwAnd(bitwShiftR(x, i), 1L)
+    ry <- bitwAnd(bitwShiftR(y, i), 1L)
+    rz <- bitwAnd(bitwShiftR(z, i), 1L)
+    digit <- bitwShiftL(rx, 2L) + bitwShiftL(ry, 1L) + rz
+    idx <- idx * 8 + digit
+    coords <- hilbert_rotate(n, x, y, z, rx, ry, rz)
+    x <- coords[1]; y <- coords[2]; z <- coords[3]
+  }
+  idx
+}
+
+compute_hindex_reference <- function(x, y, z, max_coord_bits, as_character = FALSE) {
+  res <- vapply(seq_along(x), function(i) {
+    hilbert3D_single_ref(x[i], y[i], z[i], max_coord_bits)
+  }, numeric(1))
+  if (as_character) {
+    format(res, scientific = FALSE, trim = TRUE)
+  } else {
+    res
+  }
 }
 


### PR DESCRIPTION
## Summary
- provide a pure R implementation of `compute_hindex` as a fallback
- switch between the R and C++ implementations via new `implementation` argument

## Testing
- `R CMD check` *(fails: `bash: R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68420f4d2730832da722216dc8dd115a