### PR TITLE
Cache dataset for queries

### DIFF
--- a/man/ParquetNeuroVec-class.Rd
+++ b/man/ParquetNeuroVec-class.Rd
@@ -22,5 +22,7 @@ array-like access to 4D fMRI data stored in Parquet format with spatial indexing
 \item{\code{metadata}}{list. Cached metadata from the Parquet file.}
 
 \item{\code{lazy}}{logical. Whether to use lazy loading for data access.}
+
+\item{\code{dataset}}{arrow::Dataset. Cached dataset used for queries.}
 }}
 

--- a/tests/testthat/test-ParquetNeuroVec.R
+++ b/tests/testthat/test-ParquetNeuroVec.R
@@ -42,6 +42,7 @@ test_that("ParquetNeuroVec class creation and basic functionality", {
   expect_true(file.exists(pvec@parquet_path))
   expect_equal(pvec@parquet_path, parquet_path)
   expect_true(pvec@lazy)
+  expect_true(inherits(pvec@dataset, "Dataset"))
   
   # Test metadata access
   expect_type(pvec@metadata, "list")


### PR DESCRIPTION
## Summary
- cache an `arrow::Dataset` within `ParquetNeuroVec`
- compute Morton index using the C++ helper
- test that the dataset slot is created

## Testing
- ❌ `R -q -e '1+1'` (fails: `R` command not found)

------
https://chatgpt.com/codex/tasks/task_e_684241869bc4832d8595875b0237be18